### PR TITLE
Added conde forge install possibility, updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # elabapy
 
 [![release](https://img.shields.io/pypi/v/elabapy.svg)](https://pypi.org/project/elabapy/)
+[![condarelease](https://anaconda.org/conda-forge/elabapy/badges/version.svg)](https://anaconda.org/conda-forge/elabapy)
 [![wheel](https://img.shields.io/pypi/wheel/elabapy.svg)](https://pypi.org/project/elabapy/)
 [![license](https://img.shields.io/pypi/l/elabapy.svg)](https://www.gnu.org/licenses/gpl-3.0.en.html)
 
@@ -9,20 +10,19 @@ This Python 3 library provides easy access to [eLabFTW](https://www.elabftw.net)
 
 ## Install
 
-You can install elabapy using **pip**
+You can install elabapy using **pip**:
 
 ~~~bash
 pip install --user elabapy
 ~~~
 
-or via **conda**:
+or via **conda-forge**:
 
 ~~~bash
-conda skeleton pypi elabapy
-conda-build elabapy
+conda install -c conda-forge elabapy
 ~~~
 
-or via sources:
+or from source:
 
 ~~~bash
 git clone https://github.com/elabftw/elabapy


### PR DESCRIPTION
Since it didn't exist yet I created a package for elabpy on conda-forge; it may be a bit more "friendly" for installation than the previous conda install command. Feedstock is here: https://github.com/conda-forge/elabapy-feedstock. For now I'm the only maintainer, if you @NicolasCARPi  want I can add you as maintainer. Whenever you create a new release on pypi, a bot will automatically trigger a PR to the feedstock to update the version, so as long as this package stays a simple python package it's really simple to maintain. I added a version badge, there's other badge options to choose from here: https://anaconda.org/conda-forge/elabapy/badges.